### PR TITLE
Fixes #6 - Updates tests to work with RSpec 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'rspec'
+gem 'rspec', '~> 3.3.0'
+gem 'rspec-its', '~> 1.2.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'schematron'
 require 'rspec'
+require 'rspec/its'
 
 Dir[File.dirname(__FILE__)+('/support/**/*.rb')].each { |f| require f }


### PR DESCRIPTION
RSpec 3 broke out the 'it' syntax into a separate gem.
- Added 'rspec-its' to Gemfile
- Added require to
- Added ~> gem versioning for 'rspec' and 'RSpec-its'
